### PR TITLE
Feature MechTransfer adapter

### DIFF
--- a/PortableStorage.cs
+++ b/PortableStorage.cs
@@ -99,7 +99,18 @@ namespace PortableStorage
 			GC.Collect();
 		}
 
-		public override void AddRecipes()
+        public override void PostSetupContent()
+        {
+            Mod mechTansfer = ModLoader.GetMod("MechTransfer");
+
+            if (mechTansfer != null)
+            {
+                QEChestMTAdapter adapter = new QEChestMTAdapter(this);
+                mechTansfer.Call("RegisterAdapterReflection", adapter, new int[] { TileType<Tiles.QEChest>() });
+            }
+        }
+
+        public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(this);
 			recipe.AddIngredient(ItemID.Vertebrae, 5);

--- a/PortableStorage.csproj
+++ b/PortableStorage.csproj
@@ -67,6 +67,7 @@
     <Compile Include="PSPlayer.cs" />
     <Compile Include="PSItem.cs" />
     <Compile Include="PSWorld.cs" />
+    <Compile Include="QEChestMTAdapter.cs" />
     <Compile Include="TileEntities\TEQETank.cs" />
     <Compile Include="Tiles\QETank.cs" />
     <Compile Include="Tiles\QEChest.cs" />

--- a/QEChestMTAdapter.cs
+++ b/QEChestMTAdapter.cs
@@ -1,0 +1,108 @@
+﻿using PortableStorage.TileEntities;
+using PortableStorage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.ModLoader;
+using TheOneLibrary.Base;
+using TheOneLibrary.Storage;
+using TheOneLibrary.Utility;
+using Terraria.DataStructures;
+
+namespace PortableStorage
+{
+    class QEChestMTAdapter
+    {
+        private Mod mod;
+
+        public QEChestMTAdapter(Mod mod)
+        {
+            this.mod = mod;
+        }
+
+        public bool InjectItem(int x, int y, Item item)
+        {
+            int id = mod.GetID<TEQEChest>(x, y);
+            if (id == -1)
+                return false;
+
+            TEQEChest qeChest = (TEQEChest)TileEntity.ByID[id];
+
+            bool injectedPartial = false;
+
+            if (item.maxStack > 1)
+            {
+                foreach (var i in qeChest.GetItems())
+                {
+                    if (item.IsTheSameAs(i) && i.stack < i.maxStack)
+                    {
+                        int spaceLeft = i.maxStack - i.stack;
+                        if (spaceLeft >= item.stack)
+                        {
+                            i.stack += item.stack;
+                            item.stack = 0;
+                            HandleItemChange();
+                            return true;
+                        }
+                        else
+                        {
+                            item.stack -= spaceLeft;
+                            i.stack = i.maxStack;
+                            HandleItemChange();
+                            injectedPartial = true;
+                        }
+                    }
+                }
+            }
+
+            foreach (var i in qeChest.GetItems())
+            {
+                if (i.IsAir)
+                {
+                    i.SetDefaults(item.type);
+                    i.prefix = item.prefix;
+                    i.stack = item.stack;
+                    item.stack = 0;
+                    HandleItemChange();
+                    return true;
+                }
+            }
+
+            return injectedPartial;
+        }
+
+        public IEnumerable<Tuple<Item, object>> EnumerateItems(int x, int y)
+        {
+            int id = mod.GetID<TEQEChest>(x, y);
+            if (id == -1)
+                yield break;
+
+            TEQEChest qeChest = (TEQEChest)TileEntity.ByID[id];
+
+            int slot = 0;
+            foreach (var item in qeChest.GetItems())
+            {
+                yield return Tuple.Create(item, (object)slot++);
+            }
+        }
+
+        public void TakeItem(int x, int y, object slot, int amount)
+        {
+            int id = mod.GetID<TEQEChest>(x, y);
+            if (id == -1)
+                return;
+
+            TEQEChest qeChest = (TEQEChest)TileEntity.ByID[id];
+
+            qeChest.GetItems()[(int)slot].stack -= amount;
+        }
+
+        private void HandleItemChange()
+        {
+            //TODO: Sync changes from server to clients
+        }
+    }
+}

--- a/QEChestMTAdapter.cs
+++ b/QEChestMTAdapter.cs
@@ -1,20 +1,14 @@
 ﻿using PortableStorage.TileEntities;
-using PortableStorage;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria;
-using Terraria.ModLoader;
-using TheOneLibrary.Base;
-using TheOneLibrary.Storage;
-using TheOneLibrary.Utility;
 using Terraria.DataStructures;
+using Terraria.ModLoader;
+using TheOneLibrary.Utility;
 
 namespace PortableStorage
 {
-    class QEChestMTAdapter
+    internal class QEChestMTAdapter
     {
         private Mod mod;
 


### PR DESCRIPTION
Adds MechTransfer support for quantum entangled chest.

I see you don't have any sort of multiplayer syncing on QEChests yet, so I left that bit out. You might want to sort out your multiplayer stuff before merging this.